### PR TITLE
Fix HaskellDo link

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ Welcome to the <a href="http://www.datahaskell.org">**dataHaskell**</a> document
 
 Here you can find an <a href="http://www.datahaskell.org/docs/community/current-environment.html">annotated selection of links to data science and machine learning libraries</a>, as well as overviews and benchmarks of selected <a href="http://www.datahaskell.org/docs/library/library.html">libraries</a> (such as <a href="http://www.datahaskell.org/docs/library/hmatrixla.html">HMatrix</a> and <a href="http://www.datahaskell.org/docs/library/vector.html">vector</a>).
 
-We also provide some tutorial resources for your convenience: a Haskell style guide for <a href="http://www.datahaskell.org/docs/community/contributing-with-code.html">contributing with code</a>, the <a href="http://www.datahaskell.org/docs//tutorial/haskelldo-getting-started.html">Haskell.do installation guide</a> and guidelines for <a href="http://www.datahaskell.org/docs/community/contributing-to-the-documentation.html">for contributing to the documentation</a>.
+We also provide some tutorial resources for your convenience: a Haskell style guide for <a href="http://www.datahaskell.org/docs/community/contributing-with-code.html">contributing with code</a>, the <a href="http://www.datahaskell.org/docs//help/haskelldo-getting-started.html">Haskell.do installation guide</a> and guidelines for <a href="http://www.datahaskell.org/docs/community/contributing-to-the-documentation.html">for contributing to the documentation</a>.
 
 This is a collaborative effort, so we look forward to your comments and participation ! Don't be shy and <a href="https://github.com/datahaskell/docs">send us a pull request</a>
 


### PR DESCRIPTION
The old link:

http://www.datahaskell.org/docs//tutorial/haskelldo-getting-started.html

currently shows "Not Found" so I fixed the link.